### PR TITLE
Generate ZIP file using GitHub Actions

### DIFF
--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -1,0 +1,32 @@
+name: Generate ZIP file
+
+on: [pull_request]
+
+jobs:
+    generate-zip-file:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+
+            - name: Cache node_modules
+              id: cache-node-modules
+              uses: actions/cache@v3
+              env:
+                  cache-name: cache-node-modules
+              with:
+                  path: node_modules
+                  key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+
+            - name: Setup node version and npm cache
+              uses: actions/setup-node@v3
+              with:
+                  node-version-file: '.nvmrc'
+                  cache: 'npm'
+
+            - name: Install Node dependencies
+              if: steps.cache-node-modules.outputs.cache-hit != 'true'
+              run: npm ci --no-optional
+
+            - name: Generate ZIP file
+              run: npm run package-plugin:deploy

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -35,4 +35,4 @@ jobs:
               uses: actions/upload-artifact@v2
               with:
                   name: assets-for-download
-                  path: woocommerce-blocks.zip
+                  path: woocommerce-gutenberg-products-block.zip

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -34,5 +34,5 @@ jobs:
             - name: Use the Upload Artifact GitHub Action
               uses: actions/upload-artifact@v2
               with:
-                  name: woocommerce-gutenberg-products-block.zip
+                  name: woocommerce-gutenberg-products-block
                   path: woocommerce-gutenberg-products-block.zip

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -41,4 +41,6 @@ jobs:
               with:
                     name: woocommerce-gutenberg-products-block
                     path: woocommerce-gutenberg-products-block
+                    target: woocommerce-gutenberg-products-block.zip
+
         

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -34,5 +34,5 @@ jobs:
             - name: Use the Upload Artifact GitHub Action
               uses: actions/upload-artifact@v2
               with:
-                  name: assets-for-download
+                  name: woocommerce-gutenberg-products-block.zip
                   path: woocommerce-gutenberg-products-block.zip

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -35,4 +35,4 @@ jobs:
               uses: actions/upload-artifact@v2
               with:
                   name: assets-for-download
-                  path: downloads
+                  path: woocommerce-blocks.zip

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -3,43 +3,51 @@ name: Generate ZIP file
 on: [pull_request]
 
 jobs:
-    generate-zip-file:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v3
+  generate-zip-file:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
 
-            - name: Cache node_modules
-              id: cache-node-modules
-              uses: actions/cache@v3
-              env:
-                  cache-name: cache-node-modules
-              with:
-                  path: node_modules
-                  key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
 
-            - name: Setup node version and npm cache
-              uses: actions/setup-node@v3
-              with:
-                  node-version-file: '.nvmrc'
-                  cache: 'npm'
+      - name: Setup node version and npm cache
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
 
-            - name: Install Node dependencies
-              if: steps.cache-node-modules.outputs.cache-hit != 'true'
-              run: npm ci --no-optional
+      - name: Install Node dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci --no-optional
 
-            - name: Generate ZIP file
-              run: npm run package-plugin:deploy
+      - name: Generate ZIP file
+        run: npm run package-plugin:deploy
 
-            - name: Unzip generated archive
-              uses: montudor/action-zip@v1
-              with:
-                args: unzip -qq woocommerce-gutenberg-products-block.zip -d woocommerce-gutenberg-products-block
+      - name: Unzip generated archive
+        uses: montudor/action-zip@v1
+        with:
+          args: unzip -qq woocommerce-gutenberg-products-block.zip -d woocommerce-gutenberg-products-block
 
-            - name: Use the Upload Artifact GitHub Action
-              uses: actions/upload-artifact@v2
-              with:
-                    name: woocommerce-gutenberg-products-block
-                    path: woocommerce-gutenberg-products-block
+      - name: Use the Upload Artifact GitHub Action
+        uses: actions/upload-artifact@v2
+        with:
+          name: woocommerce-gutenberg-products-block
+          path: woocommerce-gutenberg-products-block
 
-        
+      - name: Use the Download Artifact GitHub Action
+        uses: actions/download-artifact@v3
+        id: download
+        with:
+          name: woocommerce-gutenberg-products-block
+          path: woocommerce-gutenberg-products-block
+
+      - name: 'Echo download path'
+        run: echo ${{steps.download.outputs.download-path}}

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -31,24 +31,27 @@ jobs:
       - name: Generate ZIP file
         run: npm run package-plugin:deploy
 
-      # - name: Unzip generated archive
-      #   uses: montudor/action-zip@v1
-      #   with:
-      #     args: unzip -qq woocommerce-gutenberg-products-block.zip -d woocommerce-gutenberg-products-block
-
-      # - name: Use the Upload Artifact GitHub Action
-      #   uses: actions/upload-artifact@v2
-      #   with:
-      #     name: woocommerce-gutenberg-products-block
-      #     path: woocommerce-gutenberg-products-block
-
-      - name: Create release
-        uses: softprops/action-gh-release@v1
+      - name: Unzip generated archive
+        uses: montudor/action-zip@v1
         with:
-          files: woocommerce-gutenberg-products-block.zip
-          tag_name: ${{ github.ref }}
-          body: ''
-        env:
-          repository: nielslange/woo-test-environment
+          args: unzip -qq woocommerce-gutenberg-products-block.zip -d woocommerce-gutenberg-products-block
 
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: woocommerce-gutenberg-products-block
+          path: woocommerce-gutenberg-products-block
 
+      - name: Upload artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: woocommerce-gutenberg-products-block
+    
+      # - name: Create release
+      #   uses: softprops/action-gh-release@v1
+      #   with:
+      #     files: woocommerce-gutenberg-products-block.zip
+      #     tag_name: ${{ github.ref }}
+      #     body: ''
+      #   env:
+      #     repository: nielslange/woo-test-environment

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -31,19 +31,19 @@ jobs:
       - name: Generate ZIP file
         run: npm run package-plugin:deploy
 
-      - name: Unzip generated archive
-        uses: montudor/action-zip@v1
-        with:
-          args: unzip -qq woocommerce-gutenberg-products-block.zip -d woocommerce-gutenberg-products-block
+      # - name: Unzip generated archive
+      #   uses: montudor/action-zip@v1
+      #   with:
+      #     args: unzip -qq woocommerce-gutenberg-products-block.zip -d woocommerce-gutenberg-products-block
 
-      - name: Use the Upload Artifact GitHub Action
-        uses: actions/upload-artifact@v2
-        with:
-          name: woocommerce-gutenberg-products-block
-          path: woocommerce-gutenberg-products-block
+      # - name: Use the Upload Artifact GitHub Action
+      #   uses: actions/upload-artifact@v2
+      #   with:
+      #     name: woocommerce-gutenberg-products-block
+      #     path: woocommerce-gutenberg-products-block
 
       - name: Create release
-        uses: ncipollo/release-action@v1
+        uses: softprops/action-gh-release@v1
         with:
-          artifacts: "woocommerce-gutenberg-products-block"
-          token: ${{ secrets.GITHUB_TOKEN }}
+          files: woocommerce-gutenberg-products-block.zip
+

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -42,19 +42,19 @@ jobs:
           name: woocommerce-gutenberg-products-block
           path: woocommerce-gutenberg-products-block
 
-      - name: Download artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: woocommerce-gutenberg-products-block
-    
-      - name: Show artifact URL
-        run: echo ${{ env.GITHUB_WORKSPACE }}/woocommerce-gutenberg-products-block.zip
-
-      # - name: Create release
-      #   uses: softprops/action-gh-release@v1
+      # - name: Download artifact
+      #   uses: actions/download-artifact@v3
       #   with:
-      #     files: woocommerce-gutenberg-products-block.zip
-      #     tag_name: ${{ github.ref }}
-      #     body: ''
-      #   env:
-      #     repository: nielslange/woo-test-environment
+      #     name: woocommerce-gutenberg-products-block
+    
+      # - name: Show artifact URL
+      #   run: echo ${{ env.GITHUB_WORKSPACE }}/woocommerce-gutenberg-products-block.zip
+
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: woocommerce-gutenberg-products-block.zip
+          tag_name: ${{ github.ref }}
+          body: ''
+        env:
+          repository: nielslange/woocommerce-blocks-releases

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -39,6 +39,6 @@ jobs:
             - name: Use the Upload Artifact GitHub Action
               uses: actions/upload-artifact@v2
               with:
-                    name: woocommerce-gutenberg-products-block
+                    name: woocommerce-gutenberg-products-block.zip
                     path: woocommerce-gutenberg-products-block
         

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -49,6 +49,6 @@ jobs:
           tag_name: ${{ github.ref }}
           body: ''
         env:
-          GITHUB_REPOSITORY: nielslange/woo-test-environment
+          repository: nielslange/woo-test-environment
 
 

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -47,4 +47,8 @@ jobs:
         with:
           files: woocommerce-gutenberg-products-block.zip
           tag_name: ${{ github.ref }}
+          body: ''
+        env:
+          GITHUB_REPOSITORY: nielslange/woo-test-environment
+
 

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -41,6 +41,5 @@ jobs:
               with:
                     name: woocommerce-gutenberg-products-block
                     path: woocommerce-gutenberg-products-block
-                    target: woocommerce-gutenberg-products-block.zip
 
         

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -39,6 +39,6 @@ jobs:
             - name: Use the Upload Artifact GitHub Action
               uses: actions/upload-artifact@v2
               with:
-                    name: woocommerce-gutenberg-products-block.zip
+                    name: woocommerce-gutenberg-products-block
                     path: woocommerce-gutenberg-products-block
         

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -42,11 +42,14 @@ jobs:
           name: woocommerce-gutenberg-products-block
           path: woocommerce-gutenberg-products-block
 
-      - name: Upload artifact
+      - name: Download artifact
         uses: actions/download-artifact@v3
         with:
           name: woocommerce-gutenberg-products-block
     
+      - name: Show artifact URL
+        run: echo ${{ env.GITHUB_WORKSPACE }}/woocommerce-gutenberg-products-block.zip
+
       # - name: Create release
       #   uses: softprops/action-gh-release@v1
       #   with:

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -31,8 +31,14 @@ jobs:
             - name: Generate ZIP file
               run: npm run package-plugin:deploy
 
+            - name: Unzip generated archive
+              uses: montudor/action-zip@v1
+              with:
+                args: unzip -qq woocommerce-gutenberg-products-block.zip -d woocommerce-gutenberg-products-block
+
             - name: Use the Upload Artifact GitHub Action
               uses: actions/upload-artifact@v2
               with:
-                  name: woocommerce-gutenberg-products-block
-                  path: woocommerce-gutenberg-products-block.zip
+                    name: woocommerce-gutenberg-products-block
+                    path: woocommerce-gutenberg-products-block
+        

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -42,12 +42,8 @@ jobs:
           name: woocommerce-gutenberg-products-block
           path: woocommerce-gutenberg-products-block
 
-      - name: Use the Download Artifact GitHub Action
-        uses: actions/download-artifact@v3
-        id: download
+      - name: Create release
+        uses: ncipollo/release-action@v1
         with:
-          name: woocommerce-gutenberg-products-block
-          path: woocommerce-gutenberg-products-block
-
-      - name: 'Echo download path'
-        run: echo ${{steps.download.outputs.download-path}}
+          artifacts: "woocommerce-gutenberg-products-block"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -46,4 +46,5 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: woocommerce-gutenberg-products-block.zip
+          tag_name: ${{ github.ref }}
 

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -30,3 +30,9 @@ jobs:
 
             - name: Generate ZIP file
               run: npm run package-plugin:deploy
+
+            - name: Use the Upload Artifact GitHub Action
+              uses: actions/upload-artifact@v2
+              with:
+                  name: assets-for-download
+                  path: downloads


### PR DESCRIPTION
Fixes #6623

#### Notes

This PR aims to generate a ZIP file of the current PR so that this (development) version can be installed using [the custom WP-CLI command `woo-test-environment`](https://github.com/nielslange/woo-test-environment).

### Testing

#### User Facing Testing

1. Create a feature branch based on this PR.
2. Apply some changes to the codebase, e.g. adding a test file/folder to the root folder.
3. Create a PR for the new feature branch.
4. Go to https://github.com/woocommerce/woocommerce-blocks/actions/workflows/generate-zip.yml and download the ZIP file of the newly created PR.
5. Spin up a testing site using https://jurassic.ninja/ or https://tastewp.com/.
6. Upload the ZIP file from step 4.
7. Verify that the WooCommerce Blocks plugin is working as expected.
8. Verify that the WooCommerce Blocks plugin contains the file/folder as added in step 2. (On https://jurassic.ninja/ you can look up the files/folders using SSH. On https://tastewp.com/ you can use [Filester – File Manager Pro](https://wordpress.org/plugins/filester/) to look up the files/folders.

* [x] Do not include in the Testing Notes